### PR TITLE
Revert to using softprops/action-gh-release for release creation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -183,18 +183,30 @@ runs:
         BUILD_NUMBER: ${{ steps.increment-version.outputs.build-number }}
       run: ${{ github.action_path }}/scripts/create-dmg.sh
 
-    - name: Create Release
+    - name: Prepare Release
       if: inputs.create-release == 'true'
+      id: prepare_release
       shell: bash
       env:
         INPUT_PROJECT_NAME: ${{ inputs.project-name }}
-        INPUT_APP_NAME: ${{ inputs.app-name != '' && inputs.app-name || inputs.project-name }}
-        INPUT_CREATE_RELEASE: ${{ inputs.create-release }}
+        INPUT_APP_NAME: ${{ inputs.app-name }}
         INPUT_CREATE_DMG: ${{ inputs.create-dmg }}
         INPUT_DMG_BACKGROUND: ${{ inputs.dmg-background }}
         BUILD_NUMBER: ${{ steps.increment-version.outputs.build-number }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: ${{ github.action_path }}/scripts/release.sh
+
+    - name: Create Release
+      if: inputs.create-release == 'true'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ${{ steps.prepare_release.outputs.artifact-path }}
+        name: ${{ steps.prepare_release.outputs.release-name }}
+        tag_name: ${{ steps.prepare_release.outputs.release-tag }}
+        body: "Automated release for ${{ inputs.app-name }} App"
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
 
     - name: Comment on PR
       if: inputs.comment-on-pr == 'true'

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,7 +9,6 @@ APP_NAME="${INPUT_APP_NAME:-$PROJECT_NAME}"
 CREATE_DMG="${INPUT_CREATE_DMG}"
 DMG_BACKGROUND="${INPUT_DMG_BACKGROUND}"
 BUILD_NUMBER="${BUILD_NUMBER}"
-GITHUB_TOKEN="${GITHUB_TOKEN}"
 
 # Set artifact name and path
 ARTIFACT_NAME="${APP_NAME}-${BUILD_NUMBER}"
@@ -48,31 +47,7 @@ else
 fi
 
 echo "artifact-path=${ARTIFACT_PATH}" >> $GITHUB_OUTPUT
+echo "release-name=${APP_NAME} v${BUILD_NUMBER}" >> $GITHUB_OUTPUT
+echo "release-tag=v${BUILD_NUMBER}" >> $GITHUB_OUTPUT
 
-# Create GitHub Release
-echo "Creating GitHub Release..."
-RELEASE_NOTES="Release ${BUILD_NUMBER} of ${APP_NAME}"
-RELEASE_TAG="v${BUILD_NUMBER}"
-
-RELEASE_DATA=$(jq -n \
-    --arg tag "${RELEASE_TAG}" \
-    --arg name "${APP_NAME} ${RELEASE_TAG}" \
-    --arg body "${RELEASE_NOTES}" \
-    '{tag_name: $tag, name: $name, body: $body, draft: false, prerelease: false}')
-
-RELEASE_RESPONSE=$(curl -s -X POST \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
-    -H "Accept: application/vnd.github.v3+json" \
-    "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases" \
-    -d "${RELEASE_DATA}")
-
-RELEASE_ID=$(echo "${RELEASE_RESPONSE}" | jq -r .id)
-UPLOAD_URL=$(echo "${RELEASE_RESPONSE}" | jq -r .upload_url | sed -e "s/{?name,label}//")
-
-curl -s -X POST \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
-    -H "Content-Type: application/octet-stream" \
-    "${UPLOAD_URL}?name=$(basename ${ARTIFACT_PATH})" \
-    --data-binary "@${ARTIFACT_PATH}"
-
-echo "Release created successfully."
+echo "Release preparation completed."


### PR DESCRIPTION
Revert to using softprops/action-gh-release for release creation

- Replace manual release creation with softprops/action-gh-release action
- Simplify release.sh script to focus on artifact preparation
- Update action.yml to incorporate softprops/action-gh-release
- Improve reliability and error handling in release process